### PR TITLE
os.system -> subprocess

### DIFF
--- a/2017/1485197768.html
+++ b/2017/1485197768.html
@@ -15,9 +15,9 @@
 <code>
 #!/usr/bin/env python
 <br/>
-import os
+import subprocess
 <br/>
-os.system('thunar ~/Desktop/primary_work')
+subprocess.Popen(["thunar", "~/Desktop/primary_work"])
 </code>
 
 <p>Then I just moved it to a folder I have called &ldquo;programs&rdquo; in my home folder. There&rsquo;s a new command in my system: <code>pwrk</code>. </p>


### PR DESCRIPTION
You shouldn't be using os.system. According to the official documentation ( https://docs.python.org/2/library/os.html#os.system ) it states:
The subprocess module provides more powerful facilities for spawning new processes and retrieving their results; using that module is preferable to using this function. See the Replacing Older Functions with the subprocess Module section in the subprocess documentation for some helpful recipes.